### PR TITLE
change client file class constructor to have an httpclient parameter …

### DIFF
--- a/src/MigrateWcfToWebApi.Core/CodeGenerators/Client/ClientCodeFilesGenerator.cs
+++ b/src/MigrateWcfToWebApi.Core/CodeGenerators/Client/ClientCodeFilesGenerator.cs
@@ -122,9 +122,9 @@ namespace {classNamespace}
         private static HttpClient _httpClient;
         private readonly JsonSerializerSettings _jsonSerializerSettings = new JsonSerializerSettings {{TypeNameHandling = TypeNameHandling.Auto}};
 
-        public {className}(string baseUrl)
+        public {className}(HttpClient httpClient)
         {{
-            _httpClient = new HttpClient {{BaseAddress = new Uri(baseUrl)}};
+            _httpClient = httpClient;
         }}
 
 {methods}


### PR DESCRIPTION
…instead of creating a new instance.

this avoids perf issue under heavy load that creates a new instance on every service request thereby causing high tcp connections/too many open sockets